### PR TITLE
Update URL links from .com to .org

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,4 @@
 
 This is a simple static website that we plan to expand once we release our open REST API.
 
-You can view our about page live here: https://www.freecodecamp.com/about
-
+You can view our about page live here: https://www.freecodecamp.org/about

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
   <meta content="X5tHeKjV-jMLyp4VMoUhW9PAYaOjtPslV250" name="csrf-token">
   <title>Statistics about freeCodeCamp | Learn to code with free online courses, programming projects, and interview preparation for developer jobs.</title>
-  <link href="http://freecodecamp.com" rel="canonical">
+  <link href="http://freecodecamp.org" rel="canonical">
   <meta charset="utf-8">
   <meta content="IE=edge" http-equiv="X-UA-Compatible">
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
@@ -16,7 +16,7 @@
   <meta content="freeCodeCamp" property="og:site_name">
   <meta content="on" name="twitter:widgets:csp">
   <meta content="d0bc047a482c03c24f1168004c2a216a" name="p:domain_verify">
-  <meta content="http://www.freecodecamp.com" property="og:url">
+  <meta content="http://www.freecodecamp.org" property="og:url">
   <meta content="Statistics about the freeCodeCamp Community, used by millions to learn JavaScript, HTML, CSS, Node, and React." property="og:description">
   <meta content="https://s3.amazonaws.com/freecodecamp/curriculum-diagram-full.jpg" property="og:image">
   <meta content="article" property="og:type">
@@ -26,7 +26,7 @@
   <link href="https://plus.google.com/+Freecodecamp" rel="author">
   <meta content="Learn to code and build projects for nonprofits. Build your full stack web development portfolio today." name="description">
   <meta content="@freecodecamp" name="twitter:creator">
-  <meta content="http://www.freecodecamp.com" name="twitter:url">
+  <meta content="http://www.freecodecamp.org" name="twitter:url">
   <meta content="@freecodecamp" name="twitter:site">
   <meta content="summary_large_image" name="twitter:card">
   <meta content="https://s3.amazonaws.com/freecodecamp/curriculum-diagram-full.jpg" name="twitter:image:src">
@@ -156,7 +156,7 @@
           <tr>
             <td class="text-center"><i class="fa fa-medium"></i></td>
             <td>
-              <a href="//medium.freecodecamp.com" target="_blank">Our Medium publication</a>
+              <a href="//medium.freecodecamp.org" target="_blank">Our Medium publication</a>
             </td>
           </tr>
           <tr>
@@ -242,11 +242,11 @@
         <h4>Is freeCodeCamp really free?</h4>
         <p class="negative-15">Yes. Every aspect of freeCodeCamp is 100% free.</p>
         <h4>How big is the freeCodeCamp community?</h4>
-        <p class="negative-15">If you add up all the people who use our learning platform, read our <a href="https://medium.freecodecamp.com" target="_blank">Medium publication</a>, watch our <a href="https://youtube.com/freecodecamp" target="_blank">YouTube channel</a>, and post on <a href="https://forum.freecodecamp.com" target="_blank">our forum</a>, every month we're helping millions of people learn about coding and technology.</p>
+        <p class="negative-15">If you add up all the people who use our learning platform, read our <a href="https://medium.freecodecamp.org" target="_blank">Medium publication</a>, watch our <a href="https://youtube.com/freecodecamp" target="_blank">YouTube channel</a>, and post on <a href="https://forum.freecodecamp.org" target="_blank">our forum</a>, every month we're helping millions of people learn about coding and technology.</p>
         <h4>How can I help nonprofits through freeCodeCamp?</h4>
-        <p class="negative-15">Through <a href="https://medium.freecodecamp.com/open-source-for-good-1a0ea9f32d5a" target="_blank">Open Source for Good</a>.</p>
+        <p class="negative-15">Through <a href="https://medium.freecodecamp.org/open-source-for-good-1a0ea9f32d5a" target="_blank">Open Source for Good</a>.</p>
         <h4>Is freeCodeCamp itself a nonprofit?</h4>
-        <p class="negative-15">Yes, we are a <a href='https://www.freecodecamp.com/donate/'>donor-supported nonprofit</a>.</p>
+        <p class="negative-15">Yes, we are a <a href='https://www.freecodecamp.org/donate/'>donor-supported nonprofit</a>.</p>
         <h4>How long will it take me to finish freeCodeCamp's certificates?</h4>
         <p class="negative-15">Each certificate takes around 200 hours of dedicated learning. Some people may take longer. These certificates are completely self-paced, so take as long as you need.</p>
         <h4>How do I completely finish freeCodeCamp?</h4>
@@ -270,7 +270,7 @@
         <h4>Can my company advertise on freeCodeCamp?</h4>
         <p class="negative-15">We don’t show ads.</p>
         <h4>How can I support freeCodeCamp's community?</h4>
-        <p class="negative-15">You can <a href="https://www.freecodecamp.com/donate" target="_blank">set up a monthly donation to our nonprofit that you can afford</a>.</p>
+        <p class="negative-15">You can <a href="https://www.freecodecamp.org/donate" target="_blank">set up a monthly donation to our nonprofit that you can afford</a>.</p>
       </div>
     </div>
     <div class="spacer">
@@ -281,13 +281,13 @@
             <tr>
               <td>Support</td>
               <td>
-                <a href='mailto:team@freecodecamp.com'>team@freecodecamp.com</a>
+                <a href='mailto:team@freecodecamp.org'>team@freecodecamp.org</a>
               </td>
             </tr>
             <tr>
               <td>Media inquiries</td>
               <td>
-                <a href="mailto:quincy@freecodecamp.com" target="_blank">quincy@freecodecamp.com</a>
+                <a href="mailto:quincy@freecodecamp.org" target="_blank">quincy@freecodecamp.org</a>
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
I've left the Beta URL address to .com as it doesn't yet work as .org. 

Let me know if the email addresses don't work as .org yet and I can change them back.