### PR TITLE
Add preferred browser for freeCodeCamp challenges

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,6 +247,8 @@
         <p class="negative-15">Through <a href="https://medium.freecodecamp.com/open-source-for-good-1a0ea9f32d5a" target="_blank">Open Source for Good</a>.</p>
         <h4>Is freeCodeCamp itself a nonprofit?</h4>
         <p class="negative-15">Yes, we are a <a href='https://www.freecodecamp.com/donate/'>donor-supported nonprofit</a>.</p>
+        <h4>What browser should I use for freeCodeCamp challenges?</h4>
+        <p class="negative-15">freeCodeCamp challenges have been extensively tested in Google Chrome, as well as macOS Safari and Mozilla Firefox. If you find problems when rendering the challenges, we suggest you try again using one of these browsers.</p>
         <h4>How long will it take me to finish freeCodeCamp's certificates?</h4>
         <p class="negative-15">Each certificate takes around 200 hours of dedicated learning. Some people may take longer. These certificates are completely self-paced, so take as long as you need.</p>
         <h4>How do I completely finish freeCodeCamp?</h4>


### PR DESCRIPTION
As suggested by @evaristoc in the [Contributor's room](https://gitter.im/FreeCodeCamp/Contributors?at=59917f4776a757f808a181ed) and [clarification from @BerkeleyTrue](https://gitter.im/FreeCodeCamp/Contributors?at=598b1fb6210ac2692069de70) on non-support for Edge as of now. Let me know if you have comments on the changes.