### PR TITLE
Fix a minor typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
     </div>
     <div class="row">
       <div class="col-xs-12 col-sm-10 col-sm-offset-1 col-md-6 col-md-offset-3">
-        <h2 class="text-center">certifications</h2>
+        <h2 class="text-center">Certifications</h2>
         <hr>
         <ul class="population-table">
           <li class="nowrap"><span class="tag">Front End:&#9;</span><span class="text-primary">8,809</span>earned</li>


### PR DESCRIPTION
Changed `certifications` to `Certifications`.
Closes #21.