### PR TITLE
Update URL to the about page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This is a simple static website that we plan to expand once we release our open REST API.
 
-You can view our about page live here: https://www.freecodecamp.org/about
+You can view our about page live here: https://about.freecodecamp.org/


### PR DESCRIPTION
I just noticed that the URL here is outdated, hence the PR.

If user accesses the old route, they will still get redirected to the new one anyway. So feel free to close if you think the PR is unnecessary.